### PR TITLE
Update install-ubuntu.sh

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -1,4 +1,5 @@
-sudo apt-get install libuv1-dev
+sudo apt-get update
+sudo apt-get install git libuv1-dev libssl-dev gcc g++ cmake make
 git clone https://github.com/uWebSockets/uWebSockets 
 cd uWebSockets
 git checkout e94b6e1


### PR DESCRIPTION
Adding all other tools required by a clean OS installation. It's a no-op if you already have the tools, and it ensures Windows users using the Linux subsystem can start from scratch and succeed.